### PR TITLE
Add default markdown formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub fn send_message(
     let mut request_body = Map::new();
     request_body.insert("text".to_string(), Value::String(msg));
     request_body.insert("chat_id".to_string(), json!(chat_id));
+    request_body.insert("parse_mode".to_string(), Value::String("MarkdownV2".to_string()));
 
     let resp = ureq::post(&format!(
         "https://api.telegram.org/bot{token}/sendMessage",


### PR DESCRIPTION
As per https://core.telegram.org/bots/api#sendmessage - added a value for `parse_mode` so the function behaves like an app user would expect in terms of simple formatting